### PR TITLE
ドラッグアンドドロップ発動条件とターンエンドボタンの挙動

### DIFF
--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -1799,7 +1799,18 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1292877275}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1542175068}
+        m_MethodName: OnClickTurnEndButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1292877275
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2228,6 +2239,7 @@ MonoBehaviour:
   turn: 1
   playerSampleDeck: 0100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
   enemySampleDeck: 0100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
+  playerManaCost: 0
 --- !u!4 &1542175069
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardDisplay.cs
+++ b/Assets/Scripts/CardDisplay.cs
@@ -7,7 +7,7 @@ using UnityEngine.EventSystems;
 public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHandler
 {
 
-    CardModel initializeCardModel;
+    public CardModel initializeCardModel;
     public int cardId;
     [SerializeField] Text nameText;
     [SerializeField] Text hpText;
@@ -16,6 +16,7 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
     [SerializeField] Image iconImage;
     public bool playerCard;
 
+    public bool canDrag;
 
 
     public void Display(CardModel cardModel)
@@ -44,7 +45,24 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
     {
         CardDisplay card = GetComponent<CardDisplay>();
 
+        canDrag = true;
+
         if (!card.playerCard)
+        {
+            canDrag = false;
+        }
+
+        if (card.initializeCardModel.cost > GameManager.gameManagerObject.playerManaCost)
+        {
+            canDrag = false;
+        }
+
+        if (!GameManager.gameManagerObject.turn)
+        {
+            canDrag = false;
+        }
+
+        if (!canDrag)
         {
             return;
         }
@@ -56,6 +74,10 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
     // ドラッグ中の動作
     public void OnDrag(PointerEventData eventData)
     {
+        if (!canDrag)
+        {
+            return;
+        }
         CardDisplay card = GetComponent<CardDisplay>();
         if (!card.playerCard)
         {
@@ -67,6 +89,11 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
     // ドラッグ終了時の動作
     public void OnEndDrag(PointerEventData eventData)
     {
+        if (!canDrag)
+        {
+            return;
+        }
+
         CardDisplay card = GetComponent<CardDisplay>();
         if (!card.playerCard)
         {

--- a/Assets/Scripts/DropPlace.cs
+++ b/Assets/Scripts/DropPlace.cs
@@ -27,14 +27,14 @@ public class DropPlace : MonoBehaviour, IDropHandler
         }
 
         //落としてくるカードがないときは処理中断する
-        if (card != null)
+        // 落としてきたカードの親を、このスクリプトがアタッチされている
+        // GameObjectにしてやる。
+        if (card.canDrag)
         {
-            // 落としてきたカードの親を、このスクリプトがアタッチされている
-            // GameObjectにしてやる。
             Debug.Log("親が変われ！");
             card.defaultParent = this.transform;
+
+            GameManager.gameManagerObject.ReduceManaCost(card);
         }
-
-
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -32,6 +32,9 @@ public class GameManager : MonoBehaviour
 
     int defaultPlayerManaCost = 0;
     int defaultEnemyManaCost = 0;
+    // 実際のマナコスト
+    public int playerManaCost;
+    int enemyManaCost;
 
     // 他クラスでもGameManagerのオブジェクトを参照できるように、GameManagerのオブジェクトを、staticで宣言。
     public static GameManager gameManagerObject;
@@ -72,13 +75,15 @@ public class GameManager : MonoBehaviour
         if (turn)
         {
             defaultPlayerManaCost += 1;
-            displayPlayerManaCost.text = defaultPlayerManaCost.ToString();
+            playerManaCost = defaultPlayerManaCost;
+            displayPlayerManaCost.text = playerManaCost.ToString();
             StartCoroutine(PlayerTurn());
         }
         else
         {
             defaultEnemyManaCost += 1;
-            displayEnemyManaCost.text = defaultEnemyManaCost.ToString();
+            enemyManaCost = defaultEnemyManaCost;
+            displayEnemyManaCost.text = enemyManaCost.ToString();
             StartCoroutine(EnemyTurn());
         }
     }
@@ -132,10 +137,12 @@ public class GameManager : MonoBehaviour
         turn = !isTurn;
         if (turn)
         {
+            StopAllCoroutines();
             StartCoroutine(PlayerTurn());
         }
         else
         {
+            StopAllCoroutines();
             StartCoroutine(EnemyTurn());
         }
         IncreaseManaCost(turn);
@@ -171,13 +178,42 @@ public class GameManager : MonoBehaviour
         if (isPlayerTurn)
         {
             defaultPlayerManaCost++;
+            playerManaCost = defaultPlayerManaCost;
         }
         else
         {
             defaultEnemyManaCost++;
+            enemyManaCost = defaultEnemyManaCost;
         }
 
-        displayPlayerManaCost.text = defaultPlayerManaCost.ToString();
-        displayEnemyManaCost.text = defaultEnemyManaCost.ToString();
+        displayPlayerManaCost.text = playerManaCost.ToString();
+        displayEnemyManaCost.text = enemyManaCost.ToString();
+    }
+
+    public void ReduceManaCost(CardDisplay card)
+    {
+
+        if (card.playerCard)
+        {
+            playerManaCost -= card.initializeCardModel.cost;
+            displayPlayerManaCost.text = playerManaCost.ToString();
+        }
+        else
+        {
+            enemyManaCost -= card.initializeCardModel.cost;
+            displayEnemyManaCost.text = enemyManaCost.ToString();
+
+        }
+
+    }
+
+
+    public void OnClickTurnEndButton()
+    {
+        if (!this.turn)
+        {
+            return;
+        }
+        SwitchTurn(this.turn);
     }
 }


### PR DESCRIPTION
以下の仕様に変更しました。
・ターンエンドボタンを押すと、プレイヤーのターン時のみ、ターン切り替えがおこる
・ドラッグアンドドロップは、以下の条件をすべて満たすはずである。
　・ドラッグしようとするカードのマナコストが、プレイヤーのマナコスト以下である。
　・ドラッグしようとするカードは、プレイヤーのカードである。
　・プレイヤーのターン時である。
・フィールド上のカードの挙動については未実装である。