### PR TITLE
対戦に関するスクリプトその4敵の動きに関する処理（カード同士の戦い）

### DIFF
--- a/Assets/Resources/Prefab/CardPrefab.prefab
+++ b/Assets/Resources/Prefab/CardPrefab.prefab
@@ -91,6 +91,7 @@ GameObject:
   - component: {fileID: 1533526656956555607}
   - component: {fileID: 114183149252556064}
   - component: {fileID: 7671682799707450487}
+  - component: {fileID: 7800488065597283834}
   m_Layer: 5
   m_Name: CardPrefab
   m_TagString: Untagged
@@ -175,6 +176,9 @@ MonoBehaviour:
   costText: {fileID: 4690036576605534077}
   iconImage: {fileID: 4936067382767250672}
   playerCard: 0
+  canMoveToField: 0
+  canAttack: 0
+  canDrag: 0
   defaultParent: {fileID: 0}
 --- !u!114 &114183149252556064
 MonoBehaviour:
@@ -200,6 +204,18 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &7800488065597283834
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4690036575550086785}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9f462f94af3eb4419f3a228a762544b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &4690036576171438666
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -2220,6 +2220,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 922c6675d062fea4b9fbadacbca2b3b9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  enemyField: {fileID: 1720912623}
+  playerField: {fileID: 1779824472}
   cardPrefab: {fileID: 1533526656956555607, guid: c9dbb15713221414bb9aebb95732ce1a,
     type: 3}
   playerHand: {fileID: 924061452}

--- a/Assets/Scripts/AttackedCard.cs
+++ b/Assets/Scripts/AttackedCard.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class AttackedCard : MonoBehaviour, IDropHandler
+{
+    public void OnDrop(PointerEventData eventData){
+        CardDisplay attacker = eventData.pointerDrag.GetComponent<CardDisplay>();
+        CardDisplay defender = GetComponent<CardDisplay>();
+
+        GameManager.gameManagerObject.FightCard(attacker, defender);
+    }
+}
+

--- a/Assets/Scripts/AttackedCard.cs.meta
+++ b/Assets/Scripts/AttackedCard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e9f462f94af3eb4419f3a228a762544b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CardDisplay.cs
+++ b/Assets/Scripts/CardDisplay.cs
@@ -15,6 +15,8 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
     [SerializeField] Text costText;
     [SerializeField] Image iconImage;
     public bool playerCard;
+    public bool canMoveToField;
+    public bool canAttack;
 
     public bool canDrag;
 
@@ -109,6 +111,19 @@ public class CardDisplay : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndD
         GameManager.gameManagerObject.displayNumberOfPlayerHandCard.text = "x" + GameManager.gameManagerObject.playerHandCardList.Length.ToString();
 
     }
+
+
+    // カードが生きているか確認して、死んでる場合はカードを破壊
+    public void CheckAlive()
+    {
+        if (initializeCardModel.isAlive){
+            hpText.text = initializeCardModel.hp.ToString();
+        }else{
+            Destroy(this.gameObject);
+        }
+    }
+
+
 
     void Start()
     {

--- a/Assets/Scripts/CardModel.cs
+++ b/Assets/Scripts/CardModel.cs
@@ -8,6 +8,7 @@ public class CardModel {
     public int at;
     public int cost;
     public Sprite icon;
+    public bool isAlive = true;
 
     public CardModel(int cardId) {
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -110,73 +110,64 @@ public class GameManager : MonoBehaviour
     }
 
     /*敵のターンだよ*/
-    IEnumerator EnemyTurn()
-    {
-    
+    IEnumerator EnemyTurn() {
+
         Debug.Log("エネミーターン");
         enemyTurnPanel.SetActive(true);
         yield return new WaitForSeconds(2);
         enemyTurnPanel.SetActive(false);
         StartCoroutine(TimeSetting());
-        yield return new WaitForSeconds(1);
+        yield return new WaitForSeconds(2);
         CardDisplay[] enemyFieldCardList = enemyField.GetComponentsInChildren<CardDisplay>();
-        for(int i = 0; i < enemyFieldCardList.Length; i++){
+        for(int i = 0;i < enemyFieldCardList.Length;i++) {
             enemyFieldCardList[i].canAttack = true;
         }
-        GiveOutCard(enemySampleDeck, enemyHand);
+        yield return new WaitForSeconds(2);
+        GiveOutCard(enemySampleDeck,enemyHand);
 
 
         // この辺に、敵がカードを場に出す処理を記述する
         CardDisplay[] enemyHandCardList = enemyHand.GetComponentsInChildren<CardDisplay>();
-        
+
         // コスト以下のカードであれば、カードをフィールドに出し続ける
-        while(Array.Exists(enemyHandCardList, card => card.initializeCardModel.cost <= enemyManaCost)){
+        while(Array.Exists(enemyHandCardList,card => card.initializeCardModel.cost <= enemyManaCost)) {
             // 条件に合うカードすべてを選択し、配列にぶっこむ
             CardDisplay[] selectableHandCardList = Array.FindAll(enemyHandCardList, card => card.initializeCardModel.cost <= enemyManaCost);
 
             // 今は、選択可能カードの配列先頭から順番に抽出することにする
-            if (selectableHandCardList.Length > 0) {
+            if(selectableHandCardList.Length > 0) {
                 CardDisplay enemyCard = selectableHandCardList[0];
                 enemyCard.transform.SetParent(enemyField);
                 ReduceManaCost(enemyCard);
                 enemyHandCardList = enemyHand.GetComponentsInChildren<CardDisplay>();
-            }else{
+            } else {
                 break;
             }
-
-
         }
 
         // 敵カードがplayerのカードに攻撃する
         enemyFieldCardList = enemyField.GetComponentsInChildren<CardDisplay>();
 
 
-
+        // 攻撃可能カードの配列を取得
+        CardDisplay[] enemyCanAttackCardList = Array.FindAll(enemyFieldCardList, card => card.canAttack);
+        // 攻撃先（プレイヤーのフィールド）のカードを配列で取得
+        CardDisplay[] playerFieldCardList = playerField.GetComponentsInChildren<CardDisplay>();
         Debug.Log("while前");
-        while(Array.Exists(enemyFieldCardList, card => card.canAttack)){
+        yield return new WaitForSeconds(5);
+        Debug.Log(enemyCanAttackCardList.Length);
+        while(enemyCanAttackCardList.Length > 0 && playerFieldCardList.Length > 0) {
             Debug.Log("while中");
-            // 攻撃可能カードの配列を取得
-            CardDisplay[] enemyCanAttackCardList = Array.FindAll(enemyFieldCardList, card => card.canAttack);
-            // 攻撃先（プレイヤーのフィールド）のカードを配列で取得
-            CardDisplay[] playerFieldCardList = playerField.GetComponentsInChildren<CardDisplay>();
-
-            CardDisplay attacker = enemyFieldCardList[0];
-
+            CardDisplay attacker = enemyCanAttackCardList[0];
             // 攻撃先（プレイヤーのフィールド）にカードがいる場合は、攻撃する。
-            if (playerFieldCardList.Length > 0){
                 Debug.Log("while中if中");
-
                 // defenderカード（攻撃対象のカード）を選択
                 CardDisplay defender = playerFieldCardList[0];
-
-                FightCard(attacker, defender);
+                FightCard(attacker,defender);
                 yield return new WaitForSeconds(1);
-                enemyFieldCardList = enemyField.GetComponentsInChildren<CardDisplay>();
-
-
-            }
-
+            playerFieldCardList = playerField.GetComponentsInChildren<CardDisplay>();
             enemyFieldCardList = enemyField.GetComponentsInChildren<CardDisplay>();
+            enemyCanAttackCardList = Array.FindAll(enemyFieldCardList,card => card.canAttack);
         }
         yield return new WaitForSeconds(1);
         SwitchTurn(turn);


### PR DESCRIPTION
実装内容：カード同士の攻撃
・1ターン当たりの時間制限を120秒に変更
・プレイヤーのカードの挙動
　・場にあるカードの中から、攻撃可能なカードが、ドラッグアンドドロップで、
　　敵のカードに攻撃できる。
・敵のカードの挙動
　・マナコストの範囲内で、手札にあるカードを場に出せるだけ出す。
　・攻撃できるカードは、全員プレイヤーのカードに攻撃する。
　・すべてのカードが攻撃を終えたら、ターンをプレイヤーに切り替える。
・HPがゼロになったカードは破壊される。
・リーダーに対する攻撃は双方とも未実装。