### PR TITLE
ヒーローに対する攻撃の処理

### DIFF
--- a/Assets/Scenes/Battle.unity
+++ b/Assets/Scenes/Battle.unity
@@ -455,6 +455,7 @@ GameObject:
   m_Component:
   - component: {fileID: 140797465}
   - component: {fileID: 140797466}
+  - component: {fileID: 140797467}
   m_Layer: 0
   m_Name: EnemyCharacter
   m_TagString: Untagged
@@ -524,6 +525,103 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &140797467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140797464}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5bbb26ad8837ce4ba50263fb6e89e3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &196827921
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 196827922}
+  - component: {fileID: 196827924}
+  - component: {fileID: 196827923}
+  - component: {fileID: 196827925}
+  m_Layer: 5
+  m_Name: EnemyHeroHitBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &196827922
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196827921}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2025335640}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 31, y: 203.7}
+  m_SizeDelta: {x: -783, y: -449.2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &196827923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196827921}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &196827924
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196827921}
+  m_CullTransparentMesh: 0
+--- !u!114 &196827925
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 196827921}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5bbb26ad8837ce4ba50263fb6e89e3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &289754451
 GameObject:
   m_ObjectHideFlags: 0
@@ -2739,6 +2837,7 @@ GameObject:
   - component: {fileID: 2025335640}
   - component: {fileID: 2025335642}
   - component: {fileID: 2025335641}
+  - component: {fileID: 2025335643}
   m_Layer: 5
   m_Name: ButtlePanel
   m_TagString: Untagged
@@ -2773,6 +2872,7 @@ RectTransform:
   - {fileID: 1107727263}
   - {fileID: 1351267439}
   - {fileID: 1635715504}
+  - {fileID: 196827922}
   m_Father: {fileID: 84366275}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2816,3 +2916,15 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2025335639}
   m_CullTransparentMesh: 0
+--- !u!114 &2025335643
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025335639}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5bbb26ad8837ce4ba50263fb6e89e3e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/AttackedHero.cs
+++ b/Assets/Scripts/AttackedHero.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class AttackedHero : MonoBehaviour, IDropHandler
+{
+    public void OnDrop(PointerEventData eventData)
+    {
+        Debug.Log("AttackedHero called");
+        CardDisplay attacker = eventData.pointerDrag.GetComponent<CardDisplay>();
+        if (attacker.canAttack){
+            GameManager.gameManagerObject.AttackToHero(attacker, true);
+        }
+    }
+}
+

--- a/Assets/Scripts/AttackedHero.cs.meta
+++ b/Assets/Scripts/AttackedHero.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5bbb26ad8837ce4ba50263fb6e89e3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -27,6 +27,10 @@ public class GameManager : MonoBehaviour
     public CardDisplay[] playerHandCardList;
     CardDisplay[] enemyHandCardList;
 
+    // HP初期値
+    int playerHp = 1;
+    int enemyHp = 1;
+
     public static GameManager instance;
     public bool turn; //true = player, false = enemy 
     public List<int> playerSampleDeck = new List<int>() { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
@@ -57,8 +61,8 @@ public class GameManager : MonoBehaviour
         enemyHandCardList = enemyHand.GetComponentsInChildren<CardDisplay>();
 
 
-        displayPlayerHp.text = 20.ToString();
-        displayEnemyHp.text = 20.ToString();
+        displayPlayerHp.text = "HP: " + this.playerHp.ToString();
+        displayEnemyHp.text = "HP: " + this.enemyHp.ToString();
         displayPlayerManaCost.text = defaultPlayerManaCost.ToString();
         displayEnemyManaCost.text = defaultEnemyManaCost.ToString();
         displayNumberOfPlayerHandCard.text = "x" + playerHandCardList.Length.ToString();
@@ -140,6 +144,7 @@ public class GameManager : MonoBehaviour
                 enemyCard.transform.SetParent(enemyField);
                 ReduceManaCost(enemyCard);
                 enemyHandCardList = enemyHand.GetComponentsInChildren<CardDisplay>();
+                this.displayNumberOfEnemyHandCard.text = "x" + enemyHandCardList.Length.ToString();
             } else {
                 break;
             }
@@ -168,6 +173,12 @@ public class GameManager : MonoBehaviour
             playerFieldCardList = playerField.GetComponentsInChildren<CardDisplay>();
             enemyFieldCardList = enemyField.GetComponentsInChildren<CardDisplay>();
             enemyCanAttackCardList = Array.FindAll(enemyFieldCardList,card => card.canAttack);
+        }
+        while(enemyCanAttackCardList.Length > 0){
+            yield return new WaitForSeconds(1);
+            this.AttackToHero(enemyCanAttackCardList[0], false);
+            this.UpdateHpText();
+            enemyCanAttackCardList = Array.FindAll(enemyFieldCardList, card => card.canAttack);
         }
         yield return new WaitForSeconds(1);
         SwitchTurn(turn);
@@ -303,5 +314,31 @@ IEnumerator TimeSetting()
         defender.CheckAlive();
     }
 
+    public void UpdateHpText(){
+        displayPlayerHp.text = "HP: " + this.playerHp.ToString();
+        displayEnemyHp.text = "HP: " + this.enemyHp.ToString();
+        displayEnemyHp.text = "HP: " + this.enemyHp.ToString();
+    }
 
+    public void CheckPlayerAlive(){
+        if (this.playerHp <= 0){
+            Debug.Log("Player Lose");
+            StopAllCoroutines();
+        }else if(this.enemyHp <=0) {
+            Debug.Log("Player Win!");
+            StopAllCoroutines();
+        }
+    }
+
+    // プレイヤーへの攻撃
+    public void AttackToHero(CardDisplay attacker, bool isPlayerCard){
+        if (isPlayerCard) {
+            this.enemyHp -= attacker.initializeCardModel.at;
+        } else {
+            this.playerHp -= attacker.initializeCardModel.at;
+        }
+        attacker.canAttack = false;
+        this.UpdateHpText();
+        this.CheckPlayerAlive();
+    }
 }


### PR DESCRIPTION
以下の機能を追加しました。
- プレイヤーがドラッグアンドドロップにて敵ヒーローへ攻撃する動作
- プレイヤーのフィールドにカードがなかった場合、敵の攻撃可能カードがプレイヤーのヒーローを攻撃する動作

以下のバグを発見したため、修正しました。
- 敵側手札から敵側フィールドにカードを出した場合に、敵手札のカード枚数表示が更新されていないバグ

ご精査お願いします。