### PR TITLE
[create] 手札・フィールドの枚数制限

### DIFF
--- a/Assets/Scripts/DropPlace.cs
+++ b/Assets/Scripts/DropPlace.cs
@@ -31,10 +31,15 @@ public class DropPlace : MonoBehaviour, IDropHandler
         // GameObjectにしてやる。
         if (card.canDrag)
         {
-            Debug.Log("親が変われ！");
-            card.defaultParent = this.transform;
+            GameManager.gameManagerObject.playerFieldCardList = GameManager.gameManagerObject.playerField.GetComponentsInChildren<CardDisplay>();
+            if (GameManager.gameManagerObject.playerFieldCardList.Length <5)
+            {
+                Debug.Log("親が変われ！");
+                card.defaultParent = this.transform;
 
-            GameManager.gameManagerObject.ReduceManaCost(card);
+                GameManager.gameManagerObject.ReduceManaCost(card);
+            }
+          
         }
     }
 }


### PR DESCRIPTION
以下の機能を追加しました
・手札の上限を７枚、フィールドカードの上限を５枚とする
・フィールドにあるカードの枚数が上限に達している場合、フィールドにカードを出せなくする
・手札にあるカードの枚数が上限に達していて、かつ山札からカードを引いた場合、手札に加えず引いたカードを消去する